### PR TITLE
Reorder CCI Tile Toggle fields and add hints

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -524,7 +524,7 @@
         },
         "Tile": {
           "Title": "Select Tile",
-          "Hint": ""
+          "Hint": "Set visibility of these tiles"
         },
         "JournalEntry": {
           "Title": "Select Journal Entries",
@@ -536,15 +536,15 @@
         },
         "RegionBehavior": {
           "Title": "Select Region Behaviors",
-          "Hint": ""
+          "Hint": "Enable/Disable these Region Behaviors"
         },
         "PermissionDocument": {
           "Title": "Permission for Journal Entries",
-          "Hint": ""
+          "Hint": "When set to show set Document ownership to this level"
         },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
-          "Hint": ""
+          "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
         "RegionUuids": {
           "Title": "Then trigger these CCI Regions on Right Click",

--- a/system/apps/chaosium-canvas-interface-tile-toggle.mjs
+++ b/system/apps/chaosium-canvas-interface-tile-toggle.mjs
@@ -43,6 +43,13 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
           hint: 'AOV.ChaosiumCanvasInterface.TileToggle.JournalEntry.Hint'
         }
       ),
+      permissionDocument: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+        label: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionDocument.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionDocument.Hint',
+        required: true
+      }),
       journalEntryPageUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           initial: undefined,
@@ -53,6 +60,13 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
           hint: 'AOV.ChaosiumCanvasInterface.TileToggle.JournalEntryPage.Hint'
         }
       ),
+      permissionPage: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
+        label: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionPage.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionPage.Hint',
+        required: true
+      }),
       regionBehaviorUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           initial: undefined,
@@ -63,20 +77,6 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
           hint: 'AOV.ChaosiumCanvasInterface.TileToggle.RegionBehavior.Hint'
         }
       ),
-      permissionDocument: new fields.NumberField({
-        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
-        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
-        label: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionDocument.Title',
-        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionDocument.Hint',
-        required: true
-      }),
-      permissionPage: new fields.NumberField({
-        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
-        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER,
-        label: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionPage.Title',
-        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionPage.Hint',
-        required: true
-      }),
       regionUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           initial: undefined,


### PR DESCRIPTION
Add some hint translations to the CCI Tile Toggle.

Move the permission dropdowns to under the relevant DocumentUUIDField