### PR TITLE
Chaosium Canvas Interface: Play Sound, Button Triggers, duplicate Region Behaviours

### DIFF
--- a/aov.mjs
+++ b/aov.mjs
@@ -6,6 +6,7 @@ import RenderNoteConfig from './system/hooks/render-note-config.js'
 import RenderRollTableSheet from './system/hooks/render-roll-table-sheet.mjs'
 import CreateToken from './system/hooks/create-token.mjs'
 import RenderChatMessageHTML from './system/hooks/render-chat-message.mjs'
+import RenderRegionConfig from './system/hooks/render-region-config.mjs'
 
 import Init from './system/hooks/init.mjs';
 import Ready from './system/hooks/ready.mjs';
@@ -20,4 +21,4 @@ Hooks.on('renderNoteConfig', RenderNoteConfig)
 Hooks.on('renderRollTableSheet', RenderRollTableSheet);
 Hooks.on('renderChatMessageHTML', RenderChatMessageHTML);
 Hooks.on('createToken', CreateToken);
-
+Hooks.on('renderRegionConfig', RenderRegionConfig);

--- a/lang/en.json
+++ b/lang/en.json
@@ -473,7 +473,16 @@
     },
 
     "ChaosiumCanvasInterface": {
+      "Buttons": {
+        "Both": "Both Mouse Buttons",
+        "Left": "Left Mouse Button",
+        "Right": "Right Mouse Button"
+      },
       "DrawingToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the drawing and documents"
@@ -498,16 +507,36 @@
           "Title": "Permission for Journal Entries",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       },
       "MapPinToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the map note and documents"
@@ -530,6 +559,10 @@
         }
       },
       "OpenDocument": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Permission": {
           "Title": "Can click if",
           "Hint": ""
@@ -553,7 +586,29 @@
         "GM": "GM",
         "SeeTile": "See Tile"
       },
+      "PlaySound": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
+        "Playlist": {
+          "Title": "Select Playlist",
+          "Hint": ""
+        },
+        "Sound": {
+          "Title": "Select Playlist Sound",
+          "Hint": ""
+        },
+        "Toggle": {
+          "Title": "Play",
+          "Hint": "Should this play or stop playback"
+        }
+      },
       "ToScene": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Permission": {
           "Title": "Can click if",
           "Hint": ""
@@ -568,9 +623,13 @@
         }
       },
       "TileToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
-          "Hint": "Should this show or hide the map pin and documents"
+          "Hint": "Should this show or hide the tile and documents"
         },
         "Tile": {
           "Title": "Select Tile",
@@ -592,12 +651,28 @@
           "Title": "Permission for Journal Entries",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       }
@@ -1201,6 +1276,7 @@
       "ChaosiumCanvasInterfaceDrawingToggle": "CCI: Drawing Toggle",
       "ChaosiumCanvasInterfaceMapPinToggle": "CCI: Map Note Toggle",
       "ChaosiumCanvasInterfaceOpenDocument": "CCI: Open Document",
+      "ChaosiumCanvasInterfacePlaySound": "CCI: Play Sound",
       "ChaosiumCanvasInterfaceToScene": "CCI: To Scene",
       "ChaosiumCanvasInterfaceTileToggle": "CCI: Tile Toggle"
     }

--- a/system.json
+++ b/system.json
@@ -152,6 +152,7 @@
         "ChaosiumCanvasInterfaceDrawingToggle": {},
         "ChaosiumCanvasInterfaceMapPinToggle": {},
         "ChaosiumCanvasInterfaceOpenDocument": {},
+        "ChaosiumCanvasInterfacePlaySound": {},
         "ChaosiumCanvasInterfaceToScene": {},
         "ChaosiumCanvasInterfaceTileToggle": {}
       }

--- a/system/apps/chaosium-canvas-interface-init.mjs
+++ b/system/apps/chaosium-canvas-interface-init.mjs
@@ -1,6 +1,7 @@
 import ChaosiumCanvasInterfaceDrawingToggle from "./chaosium-canvas-interface-drawing-toggle.mjs";
 import ChaosiumCanvasInterfaceMapPinToggle from "./chaosium-canvas-interface-map-pin-toggle.mjs";
 import ChaosiumCanvasInterfaceOpenDocument from "./chaosium-canvas-interface-open-document.mjs";
+import ChaosiumCanvasInterfacePlaySound from "./chaosium-canvas-interface-play-sound.mjs";
 import ChaosiumCanvasInterfaceToScene from "./chaosium-canvas-interface-to-scene.mjs";
 import ChaosiumCanvasInterfaceTileToggle from "./chaosium-canvas-interface-tile-toggle.mjs";
 import ChaosiumCanvasInterface from "./chaosium-canvas-interface.mjs";
@@ -11,6 +12,7 @@ export default class ChaosiumCanvasInterfaceInit extends ChaosiumCanvasInterface
       ChaosiumCanvasInterfaceDrawingToggle,
       ChaosiumCanvasInterfaceMapPinToggle,
       ChaosiumCanvasInterfaceOpenDocument,
+      ChaosiumCanvasInterfacePlaySound,
       ChaosiumCanvasInterfaceToScene,
       ChaosiumCanvasInterfaceTileToggle
     ]

--- a/system/apps/chaosium-canvas-interface-map-pin-toggle.mjs
+++ b/system/apps/chaosium-canvas-interface-map-pin-toggle.mjs
@@ -18,6 +18,12 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'AOV.ChaosiumCanvasInterface.MapPinToggle.Button.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.MapPinToggle.Button.Hint'
+      }),
       toggle: new fields.BooleanField({
         initial: false,
         label: 'AOV.ChaosiumCanvasInterface.MapPinToggle.Toggle.Title',
@@ -25,7 +31,6 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
       }),
       noteUuids: new fields.SetField(
         new fields.DocumentUUIDField({
-          initial: undefined,
           type: 'Note'
         }),
         {
@@ -35,7 +40,6 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
       ),
       documentUuids: new fields.SetField(
         new fields.DocumentUUIDField({
-          initial: undefined
         }),
         {
           label: 'AOV.ChaosiumCanvasInterface.MapPinToggle.Document.Title',
@@ -63,7 +67,7 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
     return game.user.isGM
   }
 
-  async _handleLeftClickEvent () {
+  async #handleClickEvent () {
     game.socket.emit('system.aov', { type: 'toggleMapNotes', toggle: true })
     game.settings.set('core', foundry.canvas.layers.NotesLayer.TOGGLE_SETTING, true)
     for (const uuid of this.documentUuids) {
@@ -83,6 +87,18 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
       } else {
         console.error('Note ' + uuid + ' not loaded')
       }
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if (this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if (this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/system/apps/chaosium-canvas-interface-open-document.mjs
+++ b/system/apps/chaosium-canvas-interface-open-document.mjs
@@ -16,6 +16,12 @@ export default class ChaosiumCanvasInterfaceOpenDocument extends ChaosiumCanvasI
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'AOV.ChaosiumCanvasInterface.OpenDocument.Button.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.OpenDocument.Button.Hint'
+      }),
       permission: new fields.StringField({
         blank: false,
         choices: Object.keys(ChaosiumCanvasInterfaceOpenDocument.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceOpenDocument.PERMISSIONS[k]); return c }, {}),
@@ -58,25 +64,34 @@ export default class ChaosiumCanvasInterfaceOpenDocument extends ChaosiumCanvasI
     return false
   }
 
-async _handleLeftClickEvent () {
-    if (this.documentUuid) {
-      let doc = await fromUuid(this.documentUuid)
+  async #handleClickEvent () {
+    let doc = await fromUuid(this.documentUuid)
       if (this.pageId) {
         const page = doc.pages.get(this.pageId)
         if (page) {
           doc = page
         }
       }
-      if (doc?.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)) {
-        if (doc instanceof JournalEntryPage) {
-          doc.parent.sheet.render(true, { pageId: doc.id, anchor: this.anchor })
-        } else {
-          doc.sheet.render(true)
-        }
+    if (doc?.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)) {
+      if (doc instanceof JournalEntryPage) {
+        doc.parent.sheet.render(true, { pageId: doc.id, anchor: this.anchor })
       } else {
-        console.error('Document ' + this.documentUuid + ' not loaded')
+        doc.sheet.render(true)
       }
+    } else {
+      console.error('Document ' + this.documentUuid + ' not loaded')
     }
   }
 
+  async _handleLeftClickEvent () {
+    if (this.documentUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if (this.documentUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
+    }
+  }
 }

--- a/system/apps/chaosium-canvas-interface-play-sound.mjs
+++ b/system/apps/chaosium-canvas-interface-play-sound.mjs
@@ -1,0 +1,77 @@
+import ChaosiumCanvasInterface from "./chaosium-canvas-interface.mjs";
+
+export default class ChaosiumCanvasInterfacePlaySound extends ChaosiumCanvasInterface {
+  static get icon () {
+    return 'fa-solid fa-music'
+  }
+
+  static defineSchema () {
+    const fields = foundry.data.fields
+    return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'AOV.ChaosiumCanvasInterface.PlaySound.Button.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.PlaySound.Button.Hint'
+      }),
+      toggle: new fields.BooleanField({
+        initial: false,
+        label: 'AOV.ChaosiumCanvasInterface.PlaySound.Toggle.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.PlaySound.Toggle.Hint'
+      }),
+      playlistUuid: new fields.DocumentUUIDField({
+        label: 'AOV.ChaosiumCanvasInterface.PlaySound.Playlist.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.PlaySound.Playlist.Hint',
+        type: 'Playlist'
+      }),
+      soundUuid: new fields.DocumentUUIDField({
+        label: 'AOV.ChaosiumCanvasInterface.PlaySound.Sound.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.PlaySound.Sound.Hint',
+        type: 'PlaylistSound'
+      })
+    }
+  }
+
+  async _handleMouseOverEvent () {
+    return game.user.isGM
+  }
+
+  async #handleClickEvent () {
+    if (this.playlistUuid) {
+      const playList = await fromUuid(this.playlistUuid)
+      if (playList) {
+        if (this.toggle) {
+          playList.playAll()
+        } else {
+          playList.stopAll()
+        }
+      } else {
+        console.error('Playlist ' + this.sceneUuid + ' not loaded')
+      }
+    }
+    if (this.soundUuid) {
+      const sound = await fromUuid(this.soundUuid)
+      if (sound) {
+        if (this.toggle) {
+          sound.parent.playSound(sound)
+        } else {
+          sound.parent.stopSound(sound)
+        }
+      } else {
+        console.error('Sound ' + this.sceneUuid + ' not loaded')
+      }
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if ((this.playlistUuid || this.soundUuid) && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if ((this.playlistUuid || this.soundUuid) && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
+    }
+  }
+}

--- a/system/apps/chaosium-canvas-interface-tile-toggle.mjs
+++ b/system/apps/chaosium-canvas-interface-tile-toggle.mjs
@@ -15,9 +15,27 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
     return 'fa-solid fa-cubes'
   }
 
+  static get triggerButtons () {
+    const buttons = super.triggerButtons
+    buttons[ChaosiumCanvasInterfaceTileToggle.triggerButton.Both] = 'AOV.ChaosiumCanvasInterface.Buttons.Both'
+    return buttons
+  }
+
+  static get triggerButton () {
+    const button = super.triggerButton
+    button.Both = 20
+    return button
+  }
+
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterfaceTileToggle.triggerButtons,
+        initial: ChaosiumCanvasInterfaceTileToggle.triggerButton.Left,
+        label: 'AOV.ChaosiumCanvasInterface.TileToggle.Button.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.Button.Hint'
+      }),
       toggle: new fields.BooleanField({
         initial: false,
         label: 'AOV.ChaosiumCanvasInterface.TileToggle.Toggle.Title',
@@ -25,7 +43,6 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
       }),
       tileUuids: new fields.SetField(
         new fields.DocumentUUIDField({
-          initial: undefined,
           type: 'Tile'
         }),
         {
@@ -35,7 +52,6 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
       ),
       journalEntryUuids: new fields.SetField(
         new fields.DocumentUUIDField({
-          initial: undefined,
           type: 'JournalEntry'
         }),
         {
@@ -50,9 +66,15 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionDocument.Hint',
         required: true
       }),
+      permissionDocumentHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionDocumentHide.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionDocumentHide.Hint',
+        required: true
+      }),
       journalEntryPageUuids: new fields.SetField(
         new fields.DocumentUUIDField({
-          initial: undefined,
           type: 'JournalEntryPage'
         }),
         {
@@ -67,9 +89,15 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionPage.Hint',
         required: true
       }),
+      permissionPageHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionPageHide.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.PermissionPageHide.Hint',
+        required: true
+      }),
       regionBehaviorUuids: new fields.SetField(
         new fields.DocumentUUIDField({
-          initial: undefined,
           type: 'RegionBehavior'
         }),
         {
@@ -77,24 +105,42 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
           hint: 'AOV.ChaosiumCanvasInterface.TileToggle.RegionBehavior.Hint'
         }
       ),
+      regionButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Right,
+        label: 'AOV.ChaosiumCanvasInterface.TileToggle.TriggerButton.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.TriggerButton.Hint'
+      }),
       regionUuids: new fields.SetField(
         new fields.DocumentUUIDField({
-          initial: undefined,
           type: 'Region'
         }),
         {
-          label: 'AOV.ChaosiumCanvasInterface.TileToggle.RegionUuids.Title',
-          hint: 'AOV.ChaosiumCanvasInterface.TileToggle.RegionUuids.Hint'
+          label: 'AOV.ChaosiumCanvasInterface.TileToggle.TriggerRegionUuids.Title',
+          hint: 'AOV.ChaosiumCanvasInterface.TileToggle.TriggerRegionUuids.Hint'
         }
       ),
+      triggerAsButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'AOV.ChaosiumCanvasInterface.TileToggle.TriggerAsButton.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.TileToggle.TriggerAsButton.Hint'
+      }),
     }
+  }
+
+  static migrateData (source) {
+    if (typeof source.triggerButton === 'undefined' && source.regionUuids?.length) {
+      source.triggerButton = ChaosiumCanvasInterfaceTileToggle.triggerButton.Both
+    }
+    return source
   }
 
   async _handleMouseOverEvent () {
     return game.user.isGM
   }
 
-  async _handleLeftClickEvent () {
+  async #handleClickEvent (button) {
     for (const uuid of this.tileUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -103,8 +149,8 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         console.error('Tile ' + uuid + ' not loaded')
       }
     }
-    const permissionDocument = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionDocument)
-    const permissionPage = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionPage)
+    const permissionDocument = (!this.toggle ? this.permissionDocumentHide : this.permissionDocument)
+    const permissionPage = (!this.toggle ? this.permissionPageHide : this.permissionPage)
     for (const uuid of this.journalEntryUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -129,15 +175,30 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         console.error('Region Behavior ' + uuid + ' not loaded')
       }
     }
-  }
-
-  async _handleRightClickEvent () {
-    await this._handleLeftClickEvent()
-    for (const uuid of this.regionUuids) {
-      setTimeout(() => {
-        game.aov.ClickRegionLeftUuid(uuid)
-      }, 100)
+    if (this.triggerButton === ChaosiumCanvasInterfaceTileToggle.triggerButton.Both) {
+      for (const uuid of this.regionUuids) {
+        setTimeout(() => {
+          if (button === this.regionButton) {
+            if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Right) {
+              game.aov.ClickRegionRightUuid(uuid)
+            } else if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Left) {
+              game.aov.ClickRegionLeftUuid(uuid)
+            }
+          }
+        }, 100)
+      }
     }
   }
 
+  async _handleLeftClickEvent() {
+    if ([ChaosiumCanvasInterfaceTileToggle.triggerButton.Both, ChaosiumCanvasInterface.triggerButton.Left].includes(this.triggerButton)) {
+      this.#handleClickEvent(ChaosiumCanvasInterface.triggerButton.Left)
+    }
+  }
+
+  async _handleRightClickEvent() {
+    if ([ChaosiumCanvasInterfaceTileToggle.triggerButton.Both, ChaosiumCanvasInterface.triggerButton.Right].includes(this.triggerButton)) {
+      this.#handleClickEvent(ChaosiumCanvasInterface.triggerButton.Right)
+    }
+  }
 }

--- a/system/apps/chaosium-canvas-interface-to-scene.mjs
+++ b/system/apps/chaosium-canvas-interface-to-scene.mjs
@@ -16,6 +16,12 @@ export default class ChaosiumCanvasInterfaceToScene extends ChaosiumCanvasInterf
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'AOV.ChaosiumCanvasInterface.ToScene.Button.Title',
+        hint: 'AOV.ChaosiumCanvasInterface.ToScene.Button.Hint'
+      }),
       permission: new fields.StringField({
         blank: false,
         choices: Object.keys(ChaosiumCanvasInterfaceToScene.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceToScene.PERMISSIONS[k]); return c }, {}),
@@ -25,13 +31,11 @@ export default class ChaosiumCanvasInterfaceToScene extends ChaosiumCanvasInterf
         required: true
       }),
       sceneUuid: new fields.DocumentUUIDField({
-        initial: undefined,
         label: 'AOV.ChaosiumCanvasInterface.ToScene.Scene.Title',
         hint: 'AOV.ChaosiumCanvasInterface.ToScene.Scene.Hint',
         type: 'Scene'
       }),
       tileUuid: new fields.DocumentUUIDField({
-        initial: undefined,
         label: 'AOV.ChaosiumCanvasInterface.ToScene.Tile.Title',
         hint: 'AOV.ChaosiumCanvasInterface.ToScene.Tile.Hint',
         type: 'Tile'
@@ -56,16 +60,26 @@ export default class ChaosiumCanvasInterfaceToScene extends ChaosiumCanvasInterf
     return false
   }
 
-  async _handleLeftClickEvent () {
-    if (this.sceneUuid) {
-      const doc = await fromUuid(this.sceneUuid)
-      if (doc) {
-        setTimeout(() => {
-          doc.view()
-        }, 100)
-      } else {
-        console.error('Scene ' + this.sceneUuid + ' not loaded')
-      }
+  async #handleClickEvent () {
+    const doc = await fromUuid(this.sceneUuid)
+    if (doc) {
+      setTimeout(() => {
+        doc.view()
+      }, 100)
+    } else {
+      console.error('Scene ' + this.sceneUuid + ' not loaded')
+    }
+  }
+
+  async _handleLeftClickEvent() {
+    if (this.sceneUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent() {
+    if (this.sceneUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/system/apps/chaosium-canvas-interface.mjs
+++ b/system/apps/chaosium-canvas-interface.mjs
@@ -1,4 +1,18 @@
 export default class ChaosiumCanvasInterface extends foundry.data.regionBehaviors.RegionBehaviorType {
+  static get triggerButtons () {
+    return {
+      [ChaosiumCanvasInterface.triggerButton.Left]: 'AOV.ChaosiumCanvasInterface.Buttons.Left',
+      [ChaosiumCanvasInterface.triggerButton.Right]: 'AOV.ChaosiumCanvasInterface.Buttons.Right'
+    }
+  }
+
+  static get triggerButton () {
+    return {
+      Left: 0,
+      Right: 2
+    }
+  }
+
   static initSelf () {
     const oldOnClickLeft = foundry.canvas.layers.TokenLayer.prototype._onClickLeft
     foundry.canvas.layers.TokenLayer.prototype._onClickLeft = function (event) {

--- a/system/hooks/render-region-config.mjs
+++ b/system/hooks/render-region-config.mjs
@@ -1,0 +1,26 @@
+export default function (application, element, context, options) {
+  new foundry.applications.ux.DragDrop({
+    permissions: {
+      drop: true
+    },
+    callbacks: {
+      drop: async (event) => {
+        const dataList = JSON.parse(event.dataTransfer.getData('text/plain'))
+        if (typeof dataList.uuid === 'string') {
+          let behaviors = []
+          switch (dataList.type) {
+            case 'RegionBehavior':
+              behaviors = [(await fromUuid(dataList.uuid)).toObject()]
+              break
+            case 'Region':
+              behaviors = (await fromUuid(dataList.uuid)).toObject().behaviors
+              break
+          }
+          if (behaviors.length) {
+            RegionBehavior.create(behaviors, { parent: application.document })
+          }
+        }
+      }
+    }
+  }).bind(element.querySelector('.tab.region-behaviors'))
+}


### PR DESCRIPTION
- Add ability to pick if Left or Right click will trigger the behaviours
- Add CCI: Play Sound
- Add drop existing Region or Region Behaviour on region behaviour config tab to duplicate them
- Add hide permission to Drawing and Tile to prevent always using None

Migrate existing Toggle Drawing and Tile to Both mouse buttons so that trigger regionUuids continues to work, update trigger to the following process
- Trigger Region Button [Left / Right]
- Trigger This Region [Region]
- With A Button Click [Left / Right]